### PR TITLE
Ignore auto-generated files from build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*~
+*.swp
 build/
 /tags
 /bazel-*
@@ -5,3 +7,4 @@ bin
 bin-int
 yaml-cpp.vcxproj
 yaml-cpp.vcxproj.filters
+Makefile


### PR DESCRIPTION
This is the second in a series of PRs to clean up the build of Walnut-Chat Headless on Linux.

This PR just ensures that some auto-generated files from premake5 are ignored by Git.